### PR TITLE
Fail fast in dng sdk if an invalid tag count is seen

### DIFF
--- a/source/dng_ifd.cpp
+++ b/source/dng_ifd.cpp
@@ -351,7 +351,8 @@ bool dng_ifd::ParseTag (dng_stream &stream,
 			
 			CheckTagType (parentCode, tagCode, tagType, ttShort);
 			
-			CheckTagCount (parentCode, tagCode, tagCount, 1, 0x0FFFF);
+			if (!CheckTagCount (parentCode, tagCode, tagCount, 1, 0x0FFFF))
+				return false;
 			
 			#if qDNGValidate
 			
@@ -973,7 +974,8 @@ bool dng_ifd::ParseTag (dng_stream &stream,
 			
 			CheckTagType (parentCode, tagCode, tagType, ttShort);
 			
-			CheckTagCount (parentCode, tagCode, tagCount, 1, fSamplesPerPixel);
+			if (!CheckTagCount (parentCode, tagCode, tagCount, 1, fSamplesPerPixel))
+				return false;
 			
 			#if qDNGValidate
 			
@@ -1025,7 +1027,8 @@ bool dng_ifd::ParseTag (dng_stream &stream,
 			
 			CheckTagType (parentCode, tagCode, tagType, ttShort);
 			
-			CheckTagCount (parentCode, tagCode, tagCount, fSamplesPerPixel);
+			if (!CheckTagCount (parentCode, tagCode, tagCount, fSamplesPerPixel))
+				return false;
 			
 			#if qDNGValidate
 			


### PR DESCRIPTION
Bug: 346797131
Test: TreeHugger
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:84b0c687ce847c80a2454b206c046da8241db41b) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:445d85031ac9c1cffd06bf8b3356d9391170a319) Merged-In: I76da86b063ce4a0a329aca2a1309997cd62ac58d Change-Id: I76da86b063ce4a0a329aca2a1309997cd62ac58d